### PR TITLE
Shrunk width of text on Dreamworld end modal buttons

### DIFF
--- a/Assets/1 - Prefabs/Canvas/Dreamworld UI Canvas.prefab
+++ b/Assets/1 - Prefabs/Canvas/Dreamworld UI Canvas.prefab
@@ -843,7 +843,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 550, y: 70}
+  m_SizeDelta: {x: 186.7062, y: 70}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2414404711500570456
 CanvasRenderer:
@@ -3579,7 +3579,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 550, y: 70}
+  m_SizeDelta: {x: 192.4881, y: 70}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1835005958592153183
 CanvasRenderer:


### PR DESCRIPTION
To prevent the player from clicking the wrong button b/c an invisible text collider.