### PR TITLE
UM-216: The auto-pause feature that kicks in whenever the player focuses away from the game window activates even if they're on the Main Menu scene (where the pause menu should be inaccessible). Dismissing it causes a "pause" button to appear on the lower-left of the main menu.

### DIFF
--- a/Assets/2 - Scripts/0 - Dreamworld Scripts/PauseManager.cs
+++ b/Assets/2 - Scripts/0 - Dreamworld Scripts/PauseManager.cs
@@ -1,6 +1,6 @@
 using System;
 using UnityEngine;
-
+using UnityEngine.SceneManagement;
 /// <summary>
 /// The script responsible for handling pause logic.
 /// </summary>
@@ -12,7 +12,7 @@ public class PauseManager : MonoBehaviour
 
     void OnApplicationFocus(bool hasFocus)
     {
-        if(!hasFocus)
+        if(!hasFocus && SceneManager.GetActiveScene().buildIndex > 1)
         {
             OnPaused?.Invoke(true);
         }
@@ -21,7 +21,7 @@ public class PauseManager : MonoBehaviour
 
     void OnApplicationPause(bool pauseStatus)
     {
-        if(pauseStatus)
+        if(pauseStatus && SceneManager.GetActiveScene().buildIndex > 1)
         {   
             OnPaused?.Invoke(pauseStatus);
         }


### PR DESCRIPTION
Adds exception to focus / pause system on opening scene